### PR TITLE
Fix: Resolve React.Children.only error in routing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,41 +14,48 @@ import Register from "./pages/register";
 import NotFound from "./pages/not-found";
 import Layout from "./components/ui/layout";
 
+// Wrapper components for routes
+const DashboardRouteComponent = () => (
+  <Layout>
+    <Dashboard />
+  </Layout>
+);
+
+const ScheduleRouteComponent = () => (
+  <Layout>
+    <Schedule />
+  </Layout>
+);
+
+const SongsRouteComponent = () => (
+  <Layout>
+    <Songs />
+  </Layout>
+);
+
+const TeamRouteComponent = () => (
+  <Layout>
+    <Team />
+  </Layout>
+);
+
+const MessagesRouteComponent = () => (
+  <Layout>
+    <Messages />
+  </Layout>
+);
+
 function Router() {
   return (
     <Switch>
       <Route path="/login" component={Login} />
       <Route path="/register" component={Register} />
       
-      <Route path="/">
-        <Layout>
-          <Dashboard />
-        </Layout>
-      </Route>
-      
-      <Route path="/schedule">
-        <Layout>
-          <Schedule />
-        </Layout>
-      </Route>
-      
-      <Route path="/songs">
-        <Layout>
-          <Songs />
-        </Layout>
-      </Route>
-      
-      <Route path="/team">
-        <Layout>
-          <Team />
-        </Layout>
-      </Route>
-      
-      <Route path="/messages">
-        <Layout>
-          <Messages />
-        </Layout>
-      </Route>
+      <Route path="/" component={DashboardRouteComponent} />
+      <Route path="/schedule" component={ScheduleRouteComponent} />
+      <Route path="/songs" component={SongsRouteComponent} />
+      <Route path="/team" component={TeamRouteComponent} />
+      <Route path="/messages" component={MessagesRouteComponent} />
       
       <Route>
         <NotFound />


### PR DESCRIPTION
Refactored route definitions in `client/src/App.tsx` to address the "React.Children.only expected to receive a single React element child" error.

The issue was likely caused by nesting components directly under `wouter`'s `<Route>` component. This was resolved by:
- Creating specific wrapper components for each route that combines the `<Layout>` and the page component (e.g., `DashboardPage`, `SchedulePage`).
- Updating the `<Route>` definitions to use the `component` prop with these new wrapper components.

This change ensures that each `<Route>` deals with a single component reference, which is a more robust pattern and aligns with common usage of routing libraries, preventing the aforementioned error.